### PR TITLE
Feat disable create new recipe if user not registered

### DIFF
--- a/src/components/layout/rightbar/rightbar.tsx
+++ b/src/components/layout/rightbar/rightbar.tsx
@@ -75,13 +75,21 @@ const Rightbar: FC<Props> = ({
     }
   }
 
+  const handlePublish = () => {
+    if (isAuth) {
+      router.push('/recipe/new')
+    } else {
+      setIsModalOpen(true)
+    }
+  }
+
   return (
     <div className={styles.rightbar}>
       <div className={styles.publish}>
         <Button
           color="primary"
           size="big"
-          onClick={() => router.push('/recipe/new')}
+          onClick={handlePublish}
         >
           Опубликовать
           <Image

--- a/src/components/ui/Recipe/RecipeBody/index.tsx
+++ b/src/components/ui/Recipe/RecipeBody/index.tsx
@@ -19,6 +19,7 @@ import {
   usePublicateMutation,
   useGetRecipeDraftsQuery,
 } from '@/store/features/recipes/recipes.actions'
+import { useRedirectIfUserNotAuthorised } from '@/hooks/useRedirectIfUserNotAuthorised'
 
 const textOptions = {
   required: {
@@ -40,6 +41,8 @@ export const RecipeBody: FC<Props> = ({ recipe, readOnly }) => {
   const router = useRouter()
   const [showMediaIcons, setShowMediaIcons] = useState<boolean>(false)
   const [dataRecipe, setDataRecipe] = useState({})
+
+  useRedirectIfUserNotAuthorised();
 
   // const {
   //   data: drafts,

--- a/src/hooks/useRedirectIfUserNotAuthorised.ts
+++ b/src/hooks/useRedirectIfUserNotAuthorised.ts
@@ -1,0 +1,9 @@
+import { useAppSelector } from "@/store/hooks";
+import { useRouter } from "next/navigation";
+
+export const useRedirectIfUserNotAuthorised = () => {
+  const { isAuth } = useAppSelector((state) => state.auth);
+  const router = useRouter();
+
+  if (!isAuth) router.push('/404');
+}


### PR DESCRIPTION
Если пользователь не зарегистрирован, то при попытке создать новый рецепт появляется модальное окно с предупреждением:

![image](https://github.com/user-attachments/assets/35050085-64dd-466f-a26e-3a8e522ce606)

Сделан хук useRedirectIfUserNotAuthorised и добавлен на страницу создания рецепта - если пользователь не авторизован, происходит на 404. 
Этот хук можно использовать и в других компонентах.